### PR TITLE
Revert Index.js to use ES5 code to avoid uglification errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,16 +5,16 @@ const hslaRegex = require('hsla-regex')
 const hexRegex = require('hex-color-regex')
 const keywords = require('css-color-names')
 
-const isRgb = str => rgbRegex({exact: true}).test(str)
-const isRgba = str => rgbaRegex({exact: true}).test(str)
-const isHsl = str => hslRegex({exact: true}).test(str)
-const isHsla = str => hslaRegex({exact: true}).test(str)
-const isHex = str => hexRegex({exact: true}).test(str)
-const isKeyword = str => keywords[str] ? true : false
-const isInherit = str => str === 'inherit'
-const isCurrentColor = str => str === 'currentColor' || str === 'currentcolor'
-const isTransparent = str => str === 'transparent'
-const isColor = str => isRgb(str) || isRgba(str) || isHsl(str) || isHsla(str) || isHex(str) || isKeyword(str) || isInherit(str) || isCurrentColor(str) || isTransparent(str)
+const isRgb = function (str) { return rgbRegex({exact: true}).test(str) }
+const isRgba = function (str) { return rgbaRegex({exact: true}).test(str) }
+const isHsl = function (str) { return hslRegex({exact: true}).test(str) }
+const isHsla = function (str) { return hslaRegex({exact: true}).test(str) }
+const isHex = function (str) { return hexRegex({exact: true}).test(str) }
+const isKeyword = function (str) { return keywords[str] ? true : false }
+const isInherit = function (str) { return str === 'inherit' }
+const isCurrentColor = function (str) { return str === 'currentColor' || str === 'currentcolor' }
+const isTransparent = function (str) { return str === 'transparent' }
+const isColor = function (str) { return isRgb(str) || isRgba(str) || isHsl(str) || isHsla(str) || isHex(str) || isKeyword(str) || isInherit(str) || isCurrentColor(str) || isTransparent(str) }
 
 module.exports = isColor
 module.exports.isRgb = isRgb


### PR DESCRIPTION
Currently, the `index.js` uses ES6 code which will cause a production build error for apps created using `Create-React-App` which does not support uglification of all ES6 code, particularly arrow functions.

Considering we don't actually gain anything from using arrow functions inside the `index.js` file, I propose we convert the arrow functions to ES5 functions.

![image](https://user-images.githubusercontent.com/7637401/39273213-6730cc28-489b-11e8-8501-1bb51820c9b2.png)

I have tested the commit which resolves the uglification error.